### PR TITLE
Implement `PySparseTerm`

### DIFF
--- a/crates/accelerate/src/py_sparse_observable.rs
+++ b/crates/accelerate/src/py_sparse_observable.rs
@@ -209,6 +209,20 @@ impl PySparseTerm {
         out
     }
 
+    /// The number of qubits the term is defined on.
+    #[getter]
+    fn get_num_qubits(&self) -> PyResult<u32> {
+        let inner = self.inner.read().map_err(|_| SparseObservableReadError)?;
+        Ok(inner.num_qubits)
+    }
+
+    /// The term's coefficient.
+    #[getter]
+    fn get_coeff(&self) -> PyResult<Complex64> {
+        let inner = self.inner.read().map_err(|_| SparseObservableReadError)?;
+        Ok(inner.coeff)
+    }
+
     /// Read-only view onto the indices of each non-identity single-qubit term.
     ///
     /// The indices will always be in sorted order.
@@ -1829,7 +1843,6 @@ fn coerce_to_observable<'py>(
         Ok(obs) => Ok(Some(Bound::new(py, obs)?)),
         Err(e) => {
             if e.is_instance_of::<PyTypeError>(py) {
-                println!("Failed coercing {:?}", value);
                 Ok(None)
             } else {
                 Err(e)

--- a/crates/accelerate/src/py_sparse_observable.rs
+++ b/crates/accelerate/src/py_sparse_observable.rs
@@ -14,8 +14,8 @@ use ndarray::Array2;
 use num_complex::Complex64;
 use num_traits::Zero;
 use numpy::{
-    PyArray1, PyArray2, PyArrayDescr, PyArrayDescrMethods, PyArrayLike1, PyReadonlyArray1,
-    PyReadonlyArray2, PyUntypedArrayMethods,
+    PyArray1, PyArray2, PyArrayDescr, PyArrayDescrMethods, PyArrayLike1, PyArrayMethods,
+    PyReadonlyArray1, PyReadonlyArray2, PyUntypedArrayMethods,
 };
 use pyo3::{
     exceptions::{PyRuntimeError, PyTypeError, PyValueError, PyZeroDivisionError},
@@ -76,35 +76,184 @@ impl From<SparseObservableWriteError> for PyErr {
     }
 }
 
-// struct PySparseObservableIter<'a> {
-//     items: &'a [SparseTermView<'a>],
-//     index: usize,
-// }
+#[pyclass(name = "PyTerm", frozen, module = "qiskit.quantum_info")]
+#[derive(Clone, Debug)]
+struct PySparseTerm {
+    inner: Arc<RwLock<SparseTerm>>,
+}
 
-// impl<'a> From<&'a PySparseObservable> for PySparseObservableIter<'a> {
-//     fn from(value: &'a PySparseObservable) -> Self {
-//         let inner = value.inner.read().unwrap();
-//         let items = inner.iter().collect::<Vec<_>>();
-//         PySparseObservableIter {
-//             items: &items,
-//             index: 0,
-//         }
-//     }
-// }
+#[pymethods]
+impl PySparseTerm {
+    // Mark the Python class as being defined "within" the `SparseObservable` class namespace.
+    #[classattr]
+    #[pyo3(name = "__qualname__")]
+    fn type_qualname() -> &'static str {
+        "PySparseObservable.Term" // TODO change to SparseObservable.Term
+    }
 
-// impl<'a> Iterator for PySparseObservableIter<'a> {
-//     type Item = SparseTermView<'a>;
+    #[new]
+    #[pyo3(signature = (/, num_qubits, coeff, bit_terms, indices))]
+    fn py_new(
+        num_qubits: u32,
+        coeff: Complex64,
+        bit_terms: Vec<BitTerm>,
+        indices: Vec<u32>,
+    ) -> PyResult<Self> {
+        if bit_terms.len() != indices.len() {
+            return Err(CoherenceError::MismatchedItemCount {
+                bit_terms: bit_terms.len(),
+                indices: indices.len(),
+            }
+            .into());
+        }
+        let mut order = (0..bit_terms.len()).collect::<Vec<_>>();
+        order.sort_unstable_by_key(|a| indices[*a]);
+        let bit_terms = order.iter().map(|i| bit_terms[*i]).collect();
+        let mut sorted_indices = Vec::<u32>::with_capacity(order.len());
+        for i in order {
+            let index = indices[i];
+            if sorted_indices
+                .last()
+                .map(|prev| *prev >= index)
+                .unwrap_or(false)
+            {
+                return Err(CoherenceError::UnsortedIndices.into());
+            }
+            sorted_indices.push(index)
+        }
+        let inner = SparseTerm::new(
+            num_qubits,
+            coeff,
+            bit_terms,
+            sorted_indices.into_boxed_slice(),
+        );
+        Ok(PySparseTerm {
+            inner: Arc::new(RwLock::new(inner)),
+        })
+    }
 
-//     fn next(&mut self) -> Option<Self::Item> {
-//         if self.index < self.items.len() {
-//             let item = self.items[self.index];
-//             self.index += 1;
-//             Some(item)
-//         } else {
-//             None
-//         }
-//     }
-// }
+    /// Convert this term to a complete :class:`SparseObservable`.
+    fn to_observable(&self) -> PyResult<PySparseObservable> {
+        let inner = self.inner.read().map_err(|_| SparseObservableReadError)?;
+        let obs = SparseObservable::new(
+            inner.num_qubits,
+            vec![inner.coeff],
+            inner.bit_terms.to_vec(),
+            inner.indices.to_vec(),
+            vec![0, inner.bit_terms.len()],
+        )?;
+        Ok(PySparseObservable {
+            inner: Arc::new(RwLock::new(obs)),
+        })
+    }
+
+    fn __eq__(slf: Bound<Self>, other: Bound<PyAny>) -> PyResult<bool> {
+        if slf.is(&other) {
+            return Ok(true);
+        }
+        let Ok(other) = other.downcast_into::<Self>() else {
+            return Ok(false);
+        };
+        let slf = slf.borrow();
+        let other = other.borrow();
+        let slf_inner = slf.inner.read().map_err(|_| SparseObservableReadError)?;
+        let other_inner = other.inner.read().map_err(|_| SparseObservableReadError)?;
+        Ok(slf_inner.eq(&other_inner))
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        let inner = self.inner.read().map_err(|_| SparseObservableReadError)?;
+        Ok(format!(
+            "<{} on {} qubit{}: {}>",
+            Self::type_qualname(),
+            inner.num_qubits,
+            if inner.num_qubits == 1 { "" } else { "s" },
+            inner.view().to_sparse_str(),
+        ))
+    }
+
+    fn __getnewargs__(slf_: Bound<Self>, py: Python) -> Py<PyAny> {
+        let borrowed = slf_.borrow();
+        let inner = borrowed.inner.read().unwrap();
+        (
+            inner.num_qubits,
+            inner.coeff,
+            Self::get_bit_terms(slf_.clone()),
+            Self::get_indices(slf_),
+        )
+            .into_py(py)
+    }
+
+    /// Get a copy of this term.
+    #[pyo3(name = "copy")]
+    fn py_copy(&self) -> Self {
+        self.clone()
+    }
+
+    /// Read-only view onto the individual single-qubit terms.
+    ///
+    /// The only valid values in the array are those with a corresponding
+    /// :class:`~SparseObservable.BitTerm`.
+    #[getter]
+    fn get_bit_terms(slf_: Bound<Self>) -> Bound<PyArray1<u8>> {
+        let borrowed = slf_.borrow();
+        let inner = borrowed.inner.read().unwrap();
+        let bit_terms = &inner.bit_terms;
+        let arr = ::ndarray::aview1(::bytemuck::cast_slice::<_, u8>(bit_terms));
+        // SAFETY: in order to call this function, the lifetime of `self` must be managed by Python.
+        // We tie the lifetime of the array to `slf_`, and there are no public ways to modify the
+        // `Box<[BitTerm]>` allocation (including dropping or reallocating it) other than the entire
+        // object getting dropped, which Python will keep safe.
+        let out = unsafe { PyArray1::borrow_from_array_bound(&arr, slf_.into_any()) };
+        out.readwrite().make_nonwriteable();
+        out
+    }
+
+    /// Read-only view onto the indices of each non-identity single-qubit term.
+    ///
+    /// The indices will always be in sorted order.
+    #[getter]
+    fn get_indices(slf_: Bound<Self>) -> Bound<PyArray1<u32>> {
+        let borrowed = slf_.borrow();
+        let inner = borrowed.inner.read().unwrap();
+        let indices = &inner.indices;
+        let arr = ::ndarray::aview1(indices);
+        // SAFETY: in order to call this function, the lifetime of `self` must be managed by Python.
+        // We tie the lifetime of the array to `slf_`, and there are no public ways to modify the
+        // `Box<[u32]>` allocation (including dropping or reallocating it) other than the entire
+        // object getting dropped, which Python will keep safe.
+        let out = unsafe { PyArray1::borrow_from_array_bound(&arr, slf_.into_any()) };
+        out.readwrite().make_nonwriteable();
+        out
+    }
+
+    /// Get a :class:`.Pauli` object that represents the measurement basis needed for this term.
+    ///
+    /// For example, the projector ``0l+`` will return a Pauli ``ZXY``.  The resulting
+    /// :class:`.Pauli` is dense, in the sense that explicit identities are stored.  An identity in
+    /// the Pauli output does not require a concrete measurement.
+    ///
+    /// Returns:
+    ///     :class:`.Pauli`: the Pauli operator representing the necessary measurement basis.
+    ///
+    /// See also:
+    ///     :meth:`SparseObservable.pauli_bases`
+    ///         A similar method for an entire observable at once.
+    #[pyo3(name = "pauli_base")]
+    fn py_pauli_base<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let inner = self.inner.read().map_err(|_| SparseObservableReadError)?;
+        let mut x = vec![false; inner.num_qubits as usize];
+        let mut z = vec![false; inner.num_qubits as usize];
+        for (bit_term, index) in inner.bit_terms.iter().zip(inner.indices.iter()) {
+            x[*index as usize] = bit_term.has_x_component();
+            z[*index as usize] = bit_term.has_z_component();
+        }
+        PAULI_TYPE.get_bound(py).call1(((
+            PyArray1::from_vec_bound(py, z),
+            PyArray1::from_vec_bound(py, x),
+        ),))
+    }
+}
 
 /// Construct the Python-space `IntEnum` that represents the same values as the Rust-spce `BitTerm`.
 ///
@@ -225,11 +374,8 @@ impl PySparseObservable {
             };
             return Self::from_sparse_list(vec, num_qubits).map_err(PyErr::from);
         }
-        if let Ok(term) = data.downcast_exact::<SparseTerm>() {
-            let inner = term.borrow().to_observable();
-            return Ok(Self {
-                inner: Arc::new(RwLock::new(inner)),
-            });
+        if let Ok(term) = data.downcast_exact::<PySparseTerm>() {
+            return term.borrow().to_observable();
         };
         if let Ok(observable) = Self::from_terms(data, num_qubits) {
             return Ok(observable);
@@ -745,11 +891,21 @@ impl PySparseObservable {
                         "cannot construct an observable from an empty list without knowing `num_qubits`",
                     ));
                 };
-                first?.downcast::<SparseTerm>()?.borrow().to_observable()
+                let py_term = first?.downcast::<PySparseTerm>()?.borrow();
+                let term = py_term
+                    .inner
+                    .read()
+                    .map_err(|_| SparseObservableReadError)?;
+                term.to_observable()
             }
         };
-        for term in iter {
-            inner.add_term(term?.downcast::<SparseTerm>()?.borrow().view())?;
+        for bound_py_term in iter {
+            let py_term = bound_py_term?.downcast::<PySparseTerm>()?.borrow();
+            let term = py_term
+                .inner
+                .read()
+                .map_err(|_| SparseObservableReadError)?;
+            inner.add_term(term.view())?;
         }
         Ok(Self {
             inner: Arc::new(RwLock::new(inner)),
@@ -1085,7 +1241,14 @@ impl PySparseObservable {
     fn __getitem__(&self, py: Python, index: PySequenceIndex) -> PyResult<Py<PyAny>> {
         let inner = self.inner.read().map_err(|_| SparseObservableReadError)?;
         let indices = match index.with_len(inner.num_terms())? {
-            SequenceIndex::Int(index) => return Ok(inner.term(index).to_term().into_py(py)),
+            SequenceIndex::Int(index) => {
+                let term = inner.term(index).to_term();
+                // TODO can we just implement SparseTerm.into_py --> PySparseTerm?
+                let py_term = PySparseTerm {
+                    inner: Arc::new(RwLock::new(term)),
+                };
+                return Ok(py_term.into_py(py));
+            }
             indices => indices,
         };
         let mut out = SparseObservable::zero(inner.num_qubits());
@@ -1399,7 +1562,7 @@ impl PySparseObservable {
     #[allow(non_snake_case)]
     #[classattr]
     fn Term(py: Python) -> Bound<PyType> {
-        py.get_type_bound::<SparseTerm>()
+        py.get_type_bound::<PySparseTerm>()
     }
 }
 
@@ -1666,6 +1829,7 @@ fn coerce_to_observable<'py>(
         Ok(obs) => Ok(Some(Bound::new(py, obs)?)),
         Err(e) => {
             if e.is_instance_of::<PyTypeError>(py) {
+                println!("Failed coercing {:?}", value);
                 Ok(None)
             } else {
                 Err(e)

--- a/crates/accelerate/src/py_sparse_observable.rs
+++ b/crates/accelerate/src/py_sparse_observable.rs
@@ -64,21 +64,45 @@ impl From<SparseObservableReadError> for PyErr {
 #[derive(Error, Debug)]
 struct SparseObservableWriteError;
 
-impl From<SparseObservableWriteError> for PyErr {
-    fn from(_value: SparseObservableWriteError) -> PyErr {
-        PyRuntimeError::new_err("Poisoned write.")
-    }
-}
-
 impl ::std::fmt::Display for SparseObservableWriteError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         write!(f, "Failed acquiring lock for writing.")
     }
 }
 
-// impl From<PoisonError<RwLockReadGuard<'_, SparseObservable>>> for PyErr {
-//     fn from(value: PoisonError<PoisonError<RwLockReadGuard<'_, SparseObservable>>>) -> PyErr {
-//         PyRuntimeError::new_err(value.to_string())
+impl From<SparseObservableWriteError> for PyErr {
+    fn from(value: SparseObservableWriteError) -> PyErr {
+        PyRuntimeError::new_err(value.to_string())
+    }
+}
+
+// struct PySparseObservableIter<'a> {
+//     items: &'a [SparseTermView<'a>],
+//     index: usize,
+// }
+
+// impl<'a> From<&'a PySparseObservable> for PySparseObservableIter<'a> {
+//     fn from(value: &'a PySparseObservable) -> Self {
+//         let inner = value.inner.read().unwrap();
+//         let items = inner.iter().collect::<Vec<_>>();
+//         PySparseObservableIter {
+//             items: &items,
+//             index: 0,
+//         }
+//     }
+// }
+
+// impl<'a> Iterator for PySparseObservableIter<'a> {
+//     type Item = SparseTermView<'a>;
+
+//     fn next(&mut self) -> Option<Self::Item> {
+//         if self.index < self.items.len() {
+//             let item = self.items[self.index];
+//             self.index += 1;
+//             Some(item)
+//         } else {
+//             None
+//         }
 //     }
 // }
 

--- a/crates/accelerate/src/sparse_observable.rs
+++ b/crates/accelerate/src/sparse_observable.rs
@@ -2951,14 +2951,28 @@ impl ArrayView {
 pub struct SparseTerm {
     /// Number of qubits the entire term applies to.
     #[pyo3(get)]
-    num_qubits: u32,
+    pub(crate) num_qubits: u32,
     /// The complex coefficient of the term.
     #[pyo3(get)]
-    coeff: Complex64,
-    bit_terms: Box<[BitTerm]>,
-    indices: Box<[u32]>,
+    pub(crate) coeff: Complex64,
+    pub(crate) bit_terms: Box<[BitTerm]>,
+    pub(crate) indices: Box<[u32]>,
 }
 impl SparseTerm {
+    pub fn new(
+        num_qubits: u32,
+        coeff: Complex64,
+        bit_terms: Box<[BitTerm]>,
+        indices: Box<[u32]>,
+    ) -> Self {
+        Self {
+            num_qubits,
+            coeff,
+            bit_terms,
+            indices,
+        }
+    }
+
     pub fn view(&self) -> SparseTermView {
         SparseTermView {
             num_qubits: self.num_qubits,

--- a/test/python/quantum_info/test_py_sparse_observable.py
+++ b/test/python/quantum_info/test_py_sparse_observable.py
@@ -1806,29 +1806,29 @@ class TestSparseObservable(QiskitTestCase):
         )
         self.assertEqual(obs.pauli_bases(), expected)
 
-    # def test_iteration(self):
-    #     self.assertEqual(list(SparseObservable.zero(5)), [])
-    #     self.assertEqual(tuple(SparseObservable.zero(0)), ())
+    def test_iteration(self):
+        self.assertEqual(list(SparseObservable.zero(5)), [])
+        self.assertEqual(tuple(SparseObservable.zero(0)), ())
 
-    #     obs = SparseObservable.from_sparse_list(
-    #         [
-    #             ("Xrl", (4, 2, 1), 2j),
-    #             ("", (), 0.5),
-    #             ("01", (3, 0), -0.25),
-    #             ("+-", (2, 1), 1.0),
-    #             ("YZ", (4, 1), 1j),
-    #         ],
-    #         num_qubits=5,
-    #     )
-    #     bit_term = SparseObservable.BitTerm
-    #     expected = [
-    #         SparseObservable.Term(5, 2j, [bit_term.LEFT, bit_term.RIGHT, bit_term.X], [1, 2, 4]),
-    #         SparseObservable.Term(5, 0.5, [], []),
-    #         SparseObservable.Term(5, -0.25, [bit_term.ONE, bit_term.ZERO], [0, 3]),
-    #         SparseObservable.Term(5, 1.0, [bit_term.MINUS, bit_term.PLUS], [1, 2]),
-    #         SparseObservable.Term(5, 1j, [bit_term.Z, bit_term.Y], [1, 4]),
-    #     ]
-    #     self.assertEqual(list(obs), expected)
+        obs = SparseObservable.from_sparse_list(
+            [
+                ("Xrl", (4, 2, 1), 2j),
+                ("", (), 0.5),
+                ("01", (3, 0), -0.25),
+                ("+-", (2, 1), 1.0),
+                ("YZ", (4, 1), 1j),
+            ],
+            num_qubits=5,
+        )
+        bit_term = SparseObservable.BitTerm
+        expected = [
+            SparseObservable.Term(5, 2j, [bit_term.LEFT, bit_term.RIGHT, bit_term.X], [1, 2, 4]),
+            SparseObservable.Term(5, 0.5, [], []),
+            SparseObservable.Term(5, -0.25, [bit_term.ONE, bit_term.ZERO], [0, 3]),
+            SparseObservable.Term(5, 1.0, [bit_term.MINUS, bit_term.PLUS], [1, 2]),
+            SparseObservable.Term(5, 1j, [bit_term.Z, bit_term.Y], [1, 4]),
+        ]
+        self.assertEqual(list(obs), expected)
 
     def test_indexing(self):
         obs = SparseObservable.from_sparse_list(

--- a/test/python/quantum_info/test_py_sparse_observable.py
+++ b/test/python/quantum_info/test_py_sparse_observable.py
@@ -1873,9 +1873,9 @@ class TestSparseObservable(QiskitTestCase):
 
     @ddt.data(
         SparseObservable.identity(0),
-        # 2j * SparseObservable.identity(1),
-        # SparseObservable.identity(100),
-        # SparseObservable.from_label("IIX+-rlYZ01IIIII"),
+        2j * SparseObservable.identity(1),
+        SparseObservable.identity(100),
+        SparseObservable.from_label("IIX+-rlYZ01IIIII"),
     )
     def test_term_to_observable(self, obs):
         self.assertEqual(obs[0].to_observable(), obs)

--- a/test/python/quantum_info/test_py_sparse_observable.py
+++ b/test/python/quantum_info/test_py_sparse_observable.py
@@ -1871,151 +1871,151 @@ class TestSparseObservable(QiskitTestCase):
         self.assertIsInstance(repr(term), str)
         self.assertIn("SparseObservable.Term", repr(term))
 
-    # @ddt.data(
-    #     SparseObservable.identity(0),
-    #     2j * SparseObservable.identity(1),
-    #     SparseObservable.identity(100),
-    #     SparseObservable.from_label("IIX+-rlYZ01IIIII"),
-    # )
-    # def test_term_to_observable(self, obs):
-    #     self.assertEqual(obs[0].to_observable(), obs)
-    #     self.assertIsNot(obs[0].to_observable(), obs)
+    @ddt.data(
+        SparseObservable.identity(0),
+        # 2j * SparseObservable.identity(1),
+        # SparseObservable.identity(100),
+        # SparseObservable.from_label("IIX+-rlYZ01IIIII"),
+    )
+    def test_term_to_observable(self, obs):
+        self.assertEqual(obs[0].to_observable(), obs)
+        self.assertIsNot(obs[0].to_observable(), obs)
 
-    # def test_term_equality(self):
-    #     self.assertEqual(
-    #         SparseObservable.Term(5, 1.0, [], []), SparseObservable.Term(5, 1.0, [], [])
-    #     )
-    #     self.assertNotEqual(
-    #         SparseObservable.Term(5, 1.0, [], []), SparseObservable.Term(8, 1.0, [], [])
-    #     )
-    #     self.assertNotEqual(
-    #         SparseObservable.Term(5, 1.0, [], []), SparseObservable.Term(5, 1j, [], [])
-    #     )
-    #     self.assertNotEqual(
-    #         SparseObservable.Term(5, 1.0, [], []), SparseObservable.Term(8, -1, [], [])
-    #     )
+    def test_term_equality(self):
+        self.assertEqual(
+            SparseObservable.Term(5, 1.0, [], []), SparseObservable.Term(5, 1.0, [], [])
+        )
+        self.assertNotEqual(
+            SparseObservable.Term(5, 1.0, [], []), SparseObservable.Term(8, 1.0, [], [])
+        )
+        self.assertNotEqual(
+            SparseObservable.Term(5, 1.0, [], []), SparseObservable.Term(5, 1j, [], [])
+        )
+        self.assertNotEqual(
+            SparseObservable.Term(5, 1.0, [], []), SparseObservable.Term(8, -1, [], [])
+        )
 
-    #     obs = SparseObservable.from_list(
-    #         [
-    #             ("IIXIZ", 2j),
-    #             ("IIZIX", 2j),
-    #             ("++III", -1.5),
-    #             ("--III", -1.5),
-    #             ("IrIlI", 0.5),
-    #             ("IIrIl", 0.5),
-    #         ]
-    #     )
-    #     self.assertEqual(obs[0], obs[0])
-    #     self.assertEqual(obs[1], obs[1])
-    #     self.assertNotEqual(obs[0], obs[1])
-    #     self.assertEqual(obs[2], obs[2])
-    #     self.assertEqual(obs[3], obs[3])
-    #     self.assertNotEqual(obs[2], obs[3])
-    #     self.assertEqual(obs[4], obs[4])
-    #     self.assertEqual(obs[5], obs[5])
-    #     self.assertNotEqual(obs[4], obs[5])
+        obs = SparseObservable.from_list(
+            [
+                ("IIXIZ", 2j),
+                ("IIZIX", 2j),
+                ("++III", -1.5),
+                ("--III", -1.5),
+                ("IrIlI", 0.5),
+                ("IIrIl", 0.5),
+            ]
+        )
+        self.assertEqual(obs[0], obs[0])
+        self.assertEqual(obs[1], obs[1])
+        self.assertNotEqual(obs[0], obs[1])
+        self.assertEqual(obs[2], obs[2])
+        self.assertEqual(obs[3], obs[3])
+        self.assertNotEqual(obs[2], obs[3])
+        self.assertEqual(obs[4], obs[4])
+        self.assertEqual(obs[5], obs[5])
+        self.assertNotEqual(obs[4], obs[5])
 
-    # @ddt.data(
-    #     SparseObservable.identity(0),
-    #     2j * SparseObservable.identity(1),
-    #     SparseObservable.identity(100),
-    #     SparseObservable.from_label("IIX+-rlYZ01IIIII"),
-    # )
-    # def test_term_pickle(self, obs):
-    #     term = obs[0]
-    #     self.assertEqual(pickle.loads(pickle.dumps(term)), term)
-    #     self.assertEqual(copy.copy(term), term)
-    #     self.assertEqual(copy.deepcopy(term), term)
+    @ddt.data(
+        SparseObservable.identity(0),
+        2j * SparseObservable.identity(1),
+        SparseObservable.identity(100),
+        SparseObservable.from_label("IIX+-rlYZ01IIIII"),
+    )
+    def test_term_pickle(self, obs):
+        term = obs[0]
+        self.assertEqual(pickle.loads(pickle.dumps(term)), term)
+        self.assertEqual(copy.copy(term), term)
+        self.assertEqual(copy.deepcopy(term), term)
 
-    # def test_term_attributes(self):
-    #     term = SparseObservable.from_label("II+IIX0")[0]
-    #     self.assertEqual(term.num_qubits, 7)
-    #     self.assertEqual(term.coeff, 1.0)
-    #     np.testing.assert_equal(
-    #         term.bit_terms,
-    #         np.array(
-    #             [
-    #                 SparseObservable.BitTerm.ZERO,
-    #                 SparseObservable.BitTerm.X,
-    #                 SparseObservable.BitTerm.PLUS,
-    #             ],
-    #             dtype=np.uint8,
-    #         ),
-    #     )
-    #     np.testing.assert_equal(term.indices, np.array([0, 1, 4], dtype=np.uintp))
+    def test_term_attributes(self):
+        term = SparseObservable.from_label("II+IIX0")[0]
+        self.assertEqual(term.num_qubits, 7)
+        self.assertEqual(term.coeff, 1.0)
+        np.testing.assert_equal(
+            term.bit_terms,
+            np.array(
+                [
+                    SparseObservable.BitTerm.ZERO,
+                    SparseObservable.BitTerm.X,
+                    SparseObservable.BitTerm.PLUS,
+                ],
+                dtype=np.uint8,
+            ),
+        )
+        np.testing.assert_equal(term.indices, np.array([0, 1, 4], dtype=np.uintp))
 
-    #     term = SparseObservable.identity(10)[0]
-    #     self.assertEqual(term.num_qubits, 10)
-    #     self.assertEqual(term.coeff, 1.0)
-    #     self.assertEqual(list(term.bit_terms), [])
-    #     self.assertEqual(list(term.indices), [])
+        term = SparseObservable.identity(10)[0]
+        self.assertEqual(term.num_qubits, 10)
+        self.assertEqual(term.coeff, 1.0)
+        self.assertEqual(list(term.bit_terms), [])
+        self.assertEqual(list(term.indices), [])
 
-    #     term = SparseObservable.from_list([("IIrlZ", 0.5j)])[0]
-    #     self.assertEqual(term.num_qubits, 5)
-    #     self.assertEqual(term.coeff, 0.5j)
-    #     self.assertEqual(
-    #         list(term.bit_terms),
-    #         [
-    #             SparseObservable.BitTerm.Z,
-    #             SparseObservable.BitTerm.LEFT,
-    #             SparseObservable.BitTerm.RIGHT,
-    #         ],
-    #     )
-    #     self.assertEqual(list(term.indices), [0, 1, 2])
+        term = SparseObservable.from_list([("IIrlZ", 0.5j)])[0]
+        self.assertEqual(term.num_qubits, 5)
+        self.assertEqual(term.coeff, 0.5j)
+        self.assertEqual(
+            list(term.bit_terms),
+            [
+                SparseObservable.BitTerm.Z,
+                SparseObservable.BitTerm.LEFT,
+                SparseObservable.BitTerm.RIGHT,
+            ],
+        )
+        self.assertEqual(list(term.indices), [0, 1, 2])
 
-    # def test_term_new(self):
-    #     expected = SparseObservable.from_label("IIIX+1III")[0]
+    def test_term_new(self):
+        expected = SparseObservable.from_label("IIIX+1III")[0]
 
-    #     self.assertEqual(
-    #         SparseObservable.Term(
-    #             9,
-    #             1.0,
-    #             [
-    #                 SparseObservable.BitTerm.ONE,
-    #                 SparseObservable.BitTerm.PLUS,
-    #                 SparseObservable.BitTerm.X,
-    #             ],
-    #             [3, 4, 5],
-    #         ),
-    #         expected,
-    #     )
+        self.assertEqual(
+            SparseObservable.Term(
+                9,
+                1.0,
+                [
+                    SparseObservable.BitTerm.ONE,
+                    SparseObservable.BitTerm.PLUS,
+                    SparseObservable.BitTerm.X,
+                ],
+                [3, 4, 5],
+            ),
+            expected,
+        )
 
-    #     # Constructor should allow being given unsorted inputs, and but them in the right order.
-    #     self.assertEqual(
-    #         SparseObservable.Term(
-    #             9,
-    #             1.0,
-    #             [
-    #                 SparseObservable.BitTerm.PLUS,
-    #                 SparseObservable.BitTerm.X,
-    #                 SparseObservable.BitTerm.ONE,
-    #             ],
-    #             [4, 5, 3],
-    #         ),
-    #         expected,
-    #     )
-    #     self.assertEqual(list(expected.indices), [3, 4, 5])
+        # Constructor should allow being given unsorted inputs, and but them in the right order.
+        self.assertEqual(
+            SparseObservable.Term(
+                9,
+                1.0,
+                [
+                    SparseObservable.BitTerm.PLUS,
+                    SparseObservable.BitTerm.X,
+                    SparseObservable.BitTerm.ONE,
+                ],
+                [4, 5, 3],
+            ),
+            expected,
+        )
+        self.assertEqual(list(expected.indices), [3, 4, 5])
 
-    #     with self.assertRaisesRegex(ValueError, "not term-wise increasing"):
-    #         SparseObservable.Term(2, 2j, [SparseObservable.BitTerm.RIGHT] * 2, [0, 0])
+        with self.assertRaisesRegex(ValueError, "not term-wise increasing"):
+            SparseObservable.Term(2, 2j, [SparseObservable.BitTerm.RIGHT] * 2, [0, 0])
 
-    # def test_term_pauli_base(self):
-    #     obs = SparseObservable.from_list(
-    #         [
-    #             ("IIIII", 1.0),
-    #             ("IXYZI", 2.0),
-    #             ("+-II+", 1j),
-    #             ("rlrlr", -0.5),
-    #             ("01010", -0.25),
-    #             ("rlYII", 1.0),
-    #         ]
-    #     )
-    #     expected = [
-    #         Pauli("IIIII"),
-    #         Pauli("IXYZI"),
-    #         Pauli("XXIIX"),
-    #         Pauli("YYYYY"),
-    #         Pauli("ZZZZZ"),
-    #         Pauli("YYYII"),
-    #     ]
-    #     self.assertEqual([term.pauli_base() for term in obs], expected)
+    def test_term_pauli_base(self):
+        obs = SparseObservable.from_list(
+            [
+                ("IIIII", 1.0),
+                ("IXYZI", 2.0),
+                ("+-II+", 1j),
+                ("rlrlr", -0.5),
+                ("01010", -0.25),
+                ("rlYII", 1.0),
+            ]
+        )
+        expected = [
+            Pauli("IIIII"),
+            Pauli("IXYZI"),
+            Pauli("XXIIX"),
+            Pauli("YYYYY"),
+            Pauli("ZZZZZ"),
+            Pauli("YYYII"),
+        ]
+        self.assertEqual([term.pauli_base() for term in obs], expected)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Implement a Python-only copy of `SparseTerm`, called `PySparseTerm`.

### Details and comments

Once this is in, we can delete all Python-specific code from `sparse_observable.rs`.

